### PR TITLE
Improve find command with keyword search case insensitive implementation

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -69,7 +69,7 @@ Format: `find KEYWORD [MORE_KEYWORDS]`
 
 [NOTE]
 ====
-The search is case sensitive, the order of the keywords does not matter, only the name is searched,
+The search is case insensitive, the order of the keywords does not matter, only the name is searched,
 and persons matching at least one keyword will be returned (i.e. `OR` search).
 ====
 

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -442,14 +442,31 @@ public class AddressBook {
                 getNameFromPerson(addedPerson), getPhoneFromPerson(addedPerson), getEmailFromPerson(addedPerson));
     }
 
+//    /**
+//     * Finds and lists all persons in address book whose name contains any of the argument keywords.
+//     * Keyword matching is case sensitive.
+//     *
+//     * @param commandArgs full command args string from the user
+//     * @return feedback display message for the operation result
+//     */
+//    private static String executeFindPersons(String commandArgs) {
+//        final Set<String> keywords = extractKeywordsFromFindPersonArgs(commandArgs);
+//        final ArrayList<String[]> personsFound = getPersonsWithNameContainingAnyKeyword(keywords);
+//        showToUser(personsFound);
+//        return getMessageForPersonsDisplayedSummary(personsFound);
+//    }
+
     /**
      * Finds and lists all persons in address book whose name contains any of the argument keywords.
-     * Keyword matching is case sensitive.
+     * Keyword matching is case insensitive.
      *
      * @param commandArgs full command args string from the user
      * @return feedback display message for the operation result
      */
     private static String executeFindPersons(String commandArgs) {
+        // Convert command arguments to upper case for the implementation of keyword
+        // matching to case insensitive in the find command.
+        commandArgs = commandArgs.toUpperCase();
         final Set<String> keywords = extractKeywordsFromFindPersonArgs(commandArgs);
         final ArrayList<String[]> personsFound = getPersonsWithNameContainingAnyKeyword(keywords);
         showToUser(personsFound);
@@ -476,8 +493,26 @@ public class AddressBook {
         return new HashSet<>(splitByWhitespace(findPersonCommandArgs.trim()));
     }
 
+//    /**
+//     * Retrieves all persons in the full model whose names contain some of the specified keywords.
+//     *
+//     * @param keywords for searching
+//     * @return list of persons in full model with name containing some of the keywords
+//     */
+//    private static ArrayList<String[]> getPersonsWithNameContainingAnyKeyword(Collection<String> keywords) {
+//        final ArrayList<String[]> matchedPersons = new ArrayList<>();
+//        for (String[] person : getAllPersonsInAddressBook()) {
+//            final Set<String> wordsInName = new HashSet<>(splitByWhitespace(getNameFromPerson(person)));
+//            if (!Collections.disjoint(wordsInName, keywords)) {
+//                matchedPersons.add(person);
+//            }
+//        }
+//        return matchedPersons;
+//    }
+
     /**
      * Retrieves all persons in the full model whose names contain some of the specified keywords.
+     * Keyword matching is case insensitive.
      *
      * @param keywords for searching
      * @return list of persons in full model with name containing some of the keywords
@@ -485,7 +520,7 @@ public class AddressBook {
     private static ArrayList<String[]> getPersonsWithNameContainingAnyKeyword(Collection<String> keywords) {
         final ArrayList<String[]> matchedPersons = new ArrayList<>();
         for (String[] person : getAllPersonsInAddressBook()) {
-            final Set<String> wordsInName = new HashSet<>(splitByWhitespace(getNameFromPerson(person)));
+            final Set<String> wordsInName = new HashSet<>(splitByWhitespace(getNameFromPerson(person).toUpperCase()));
             if (!Collections.disjoint(wordsInName, keywords)) {
                 matchedPersons.add(person);
             }

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -184,8 +184,9 @@
 || 0 persons found!
 || ===================================================
 || Enter command: || [Command entered:  find betsy]
+|| 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
 || 
-|| 0 persons found!
+|| 1 persons found!
 || ===================================================
 || Enter command: || [Command entered:  find Betsy]
 || 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg

--- a/test/input.txt
+++ b/test/input.txt
@@ -51,7 +51,7 @@
   find bet
   # does not match if none have keyword
   find 23912039120
-  # matching should be case-sensitive
+  # matching should be case-insensitive
   find betsy
 
   # find unique keyword


### PR DESCRIPTION
The find command implementation has been improved such that keyword search is now case insensitive. 

The user guide documentation has also been updated to reflect the change of the find command's keyword search implementation to case insensitive.

Test with runtests.bat in test folder with updated input.txt and expected.txt test cases to reflect the change of the find command's keyword search implementation to case insensitive. It shows the correct outputs.