### PR TITLE
Fix source code to ensure consistency

### DIFF
--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -1103,7 +1103,7 @@ public class AddressBook {
     private static String getUsageInfoForAllCommands() {
         return getUsageInfoForAddCommand() + LS
                 + getUsageInfoForFindCommand() + LS
-                + getUsageInfoForViewCommand() + LS
+                + getUsageInfoForListCommand() + LS
                 + getUsageInfoForDeleteCommand() + LS
                 + getUsageInfoForClearCommand() + LS
                 + getUsageInfoForExitCommand() + LS
@@ -1137,8 +1137,8 @@ public class AddressBook {
                 + String.format(MESSAGE_COMMAND_HELP_EXAMPLE, COMMAND_CLEAR_EXAMPLE) + LS;
     }
 
-    /** Returns the string for showing 'view' command usage instruction */
-    private static String getUsageInfoForViewCommand() {
+    /** Returns the string for showing 'list' command usage instruction */
+    private static String getUsageInfoForListCommand() {
         return String.format(MESSAGE_COMMAND_HELP, COMMAND_LIST_WORD, COMMAND_LIST_DESC) + LS
                 + String.format(MESSAGE_COMMAND_HELP_EXAMPLE, COMMAND_LIST_EXAMPLE) + LS;
     }


### PR DESCRIPTION
Rename getUsageInfoForViewCommand() to getUsageInfoForListCommand() to ensure consistency with the UserGuide.adoc where there is no view command but there is a list command shown in the guide which has the similar function when the command is called.
Rename the comments for the getUsageInfoForListCommand() method to show that it shows the list command usage instruction instead of the view command usage instruction as the view command is documented as the list command in the UserGuide.adoc and also in the COMMAND_LIST_WORD static String constant in the soruce code
Test with runtests.bat and it shows the correct output